### PR TITLE
Improve help window

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,22 +36,8 @@ jobs:
           java-version: '17'
           java-package: jdk+fx
 
-      - name: Install dependencies (Linux)
-        if: matrix.platform == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-0 xvfb
-
-      - name: Start Xvfb
-        if: matrix.platform == 'ubuntu-latest'
-        run: |
-          export DISPLAY=:99.0
-          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        env:
-          DISPLAY: ":99.0"
-
       - name: Build and check with Gradle
         run: ./gradlew check coverage
-        env:
-          _JAVA_OPTIONS: "-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw"
 
       - name: Upload coverage reports to Codecov
         if: runner.os == 'Linux'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,8 +36,22 @@ jobs:
           java-version: '17'
           java-package: jdk+fx
 
+      - name: Install dependencies (Linux)
+        if: matrix.platform == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-0 xvfb
+
+      - name: Start Xvfb
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          export DISPLAY=:99.0
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        env:
+          DISPLAY: ":99.0"
+
       - name: Build and check with Gradle
         run: ./gradlew check coverage
+        env:
+          _JAVA_OPTIONS: "-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw"
 
       - name: Upload coverage reports to Codecov
         if: runner.os == 'Linux'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'application'
     id 'jacoco'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 mainClassName = 'seedu.address.Main'
@@ -61,8 +62,12 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
-
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
+    testImplementation 'org.testfx:testfx-core:4.0.18'
+    testImplementation 'org.testfx:testfx-junit5:4.0.18'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.13.2'
 }
 
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ checkstyle {
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+    jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED'
 }
 
 task coverage(type: JacocoReport) {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ checkstyle {
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+    systemProperty 'java.awt.headless', 'true'
     jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED'
     jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation 'org.openjfx:javafx-web:17'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ checkstyle {
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
-    systemProperty 'java.awt.headless', 'true'
     jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.application=ALL-UNNAMED'
     jvmArgs '--add-opens', 'javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED'
 }
@@ -64,6 +63,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
+    testImplementation "org.testfx:openjfx-monocle:8u76-b04"
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
     testImplementation 'org.testfx:testfx-core:4.0.18'

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,5 +1,9 @@
 package seedu.address.ui;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
@@ -8,7 +12,10 @@ import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
 import seedu.address.commons.core.LogsCenter;
+import java.awt.Desktop;
 
 /**
  * Controller for a help page
@@ -22,10 +29,13 @@ public class HelpWindow extends UiPart<Stage> {
     private static final String FXML = "HelpWindow.fxml";
 
     @FXML
-    private Button copyButton;
+    private Button urlButton;
 
     @FXML
     private Label helpMessage;
+
+    @FXML
+    private  WebView webView;
 
     /**
      * Creates a new HelpWindow.
@@ -35,6 +45,7 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
+        loadUserGuide();
     }
 
     /**
@@ -90,6 +101,14 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
     /**
+     * Loads the user guide URL in the WebView.
+     */
+    public void loadUserGuide() {
+        WebEngine webEngine = webView.getEngine();
+        webEngine.load(USERGUIDE_URL);
+    }
+
+    /**
      * Copies the URL to the user guide to the clipboard.
      */
     @FXML
@@ -98,5 +117,15 @@ public class HelpWindow extends UiPart<Stage> {
         final ClipboardContent url = new ClipboardContent();
         url.putString(USERGUIDE_URL);
         clipboard.setContent(url);
+    }
+
+    @FXML
+    private void openUrlInBrowser() {
+        try {
+            Desktop.getDesktop().browse(new URI(USERGUIDE_URL));
+            logger.fine("Opened URL: " + USERGUIDE_URL);
+        } catch (IOException | URISyntaxException e) {
+            logger.warning("Failed to open URL: " + USERGUIDE_URL);
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -108,6 +108,10 @@ public class HelpWindow extends UiPart<Stage> {
         webEngine.load(USERGUIDE_URL);
     }
 
+    public void showHelp() {
+        openUrlInBrowser();
+    }
+
     /**
      * Copies the URL to the user guide to the clipboard.
      */

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -9,8 +9,6 @@ import java.util.logging.Logger;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
@@ -109,17 +107,6 @@ public class HelpWindow extends UiPart<Stage> {
 
     public void showHelp() {
         openUrlInBrowser();
-    }
-
-    /**
-     * Copies the URL to the user guide to the clipboard.
-     */
-    @FXML
-    private void copyUrl() {
-        final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent url = new ClipboardContent();
-        url.putString(USERGUIDE_URL);
-        clipboard.setContent(url);
     }
 
     @FXML

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,9 +1,9 @@
 package seedu.address.ui;
 
+import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
@@ -11,11 +11,10 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
-import javafx.stage.Stage;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
+import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
-import java.awt.Desktop;
 
 /**
  * Controller for a help page
@@ -35,7 +34,7 @@ public class HelpWindow extends UiPart<Stage> {
     private Label helpMessage;
 
     @FXML
-    private  WebView webView;
+    private WebView webView;
 
     /**
      * Creates a new HelpWindow.

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -41,6 +41,8 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow(Stage root) {
         super(FXML, root);
+        assert webView != null : "WebView must be initialized";
+        assert helpMessage != null : "Help message label must be initialized";
         helpMessage.setText(HELP_MESSAGE);
         loadUserGuide();
     }

--- a/src/main/resources/view/CherHelpWindow.css
+++ b/src/main/resources/view/CherHelpWindow.css
@@ -1,16 +1,16 @@
-#copyButton, #helpMessage {
+#urlButton, #helpMessage {
     -fx-text-fill: black; /* Keep text black for light theme */
 }
 
-#copyButton {
+#urlButton {
     -fx-background-color: lightgray; /* Light background for copy button */
 }
 
-#copyButton:hover {
+#urlButton:hover {
     -fx-background-color: gainsboro; /* Slightly darker shade for hover effect */
 }
 
-#copyButton:armed {
+#urlButton:armed {
     -fx-background-color: silver; /* Even darker shade when button is pressed */
 }
 

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,16 +1,16 @@
-#copyButton, #helpMessage {
+#urlButton, #helpMessage {
     -fx-text-fill: white;
 }
 
-#copyButton {
+#urlButton {
     -fx-background-color: dimgray;
 }
 
-#copyButton:hover {
+#urlButton:hover {
     -fx-background-color: gray;
 }
 
-#copyButton:armed {
+#urlButton:armed {
     -fx-background-color: darkgray;
 }
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -8,6 +8,9 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
+<?import javafx.scene.web.WebView?>
+<?import javafx.scene.layout.VBox?>
+
 
 <fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
@@ -18,27 +21,29 @@
       <stylesheets>
         <URL value="@CherHelpWindow.css" />
       </stylesheets>
-
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
-        <children>
-          <Label fx:id="helpMessage" text="Label">
-            <HBox.margin>
-              <Insets right="5.0" />
-            </HBox.margin>
-          </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-            <HBox.margin>
-              <Insets left="5.0" />
-            </HBox.margin>
-          </Button>
-        </children>
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
-        <padding>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </padding>
-      </HBox>
+      <VBox>
+        <WebView fx:id="webView" prefHeight="600.0" prefWidth="800.0" />
+        <HBox alignment="CENTER" fx:id="helpMessageContainer">
+          <children>
+            <Label fx:id="helpMessage" text="Label">
+              <HBox.margin>
+                <Insets right="5.0" />
+              </HBox.margin>
+            </Label>
+            <Button fx:id="urlButton" mnemonicParsing="false" onAction="#openUrlInBrowser" text="Open In Browser">
+              <HBox.margin>
+                <Insets left="5.0" />
+              </HBox.margin>
+            </Button>
+          </children>
+          <opaqueInsets>
+            <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+          </opaqueInsets>
+          <padding>
+            <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+          </padding>
+        </HBox>
+      </VBox>
     </Scene>
   </scene>
 </fx:root>

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,0 +1,30 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HelpWindowTest {
+
+    private HelpWindow helpWindow;
+
+    @BeforeEach
+    public void setUp() {
+        helpWindow = new HelpWindow();
+    }
+
+    @Test
+    public void createHelpWindowWithNoException() {
+        assertDoesNotThrow(()-> {
+            new HelpWindow();
+        });
+    }
+
+    @Test
+    public void openHelpWindowUrlWithNoException() {
+        assertDoesNotThrow(()-> {
+            helpWindow.showHelp();
+        });
+    }
+}

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,16 +1,31 @@
 package seedu.address.ui;
-
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
 
-public class HelpWindowTest {
+import javafx.stage.Stage;
+
+
+public class HelpWindowTest extends ApplicationTest {
+
+    private HelpWindow helpWindow;
+
+    @Override
+    public void start(Stage primaryStage) {
+        helpWindow = new HelpWindow(primaryStage);
+    }
+
     @Test
-    public void constantsAreSetCorrectly() {
-        String expectedUrl = "https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html";
-        assertEquals("https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html",
-                HelpWindow.USERGUIDE_URL);
-        assertEquals("Refer to the user guide: https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html",
-                HelpWindow.HELP_MESSAGE);
+    public void checkUserGuideUrl() {
+        assertEquals("https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html", HelpWindow.USERGUIDE_URL);
+    }
+
+    @Test
+    public void checkOpenUrlInBrowser() {
+        assertDoesNotThrow(()-> {
+            helpWindow.showHelp();
+        });
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,30 +1,16 @@
 package seedu.address.ui;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class HelpWindowTest {
-
-    private HelpWindow helpWindow;
-
-    @BeforeEach
-    public void setUp() {
-        helpWindow = new HelpWindow();
-    }
-
     @Test
-    public void createHelpWindowWithNoException() {
-        assertDoesNotThrow(()-> {
-            new HelpWindow();
-        });
-    }
-
-    @Test
-    public void openHelpWindowUrlWithNoException() {
-        assertDoesNotThrow(()-> {
-            helpWindow.showHelp();
-        });
+    public void constantsAreSetCorrectly() {
+        String expectedUrl = "https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html";
+        assertEquals("https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html",
+                HelpWindow.USERGUIDE_URL);
+        assertEquals("Refer to the user guide: https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html",
+                HelpWindow.HELP_MESSAGE);
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.testfx.framework.junit5.ApplicationTest;
+import org.testfx.framework.junit5.Start;
 
 import javafx.stage.Stage;
 
@@ -11,10 +12,9 @@ import javafx.stage.Stage;
 public class HelpWindowTest extends ApplicationTest {
 
     private HelpWindow helpWindow;
-    @Override
+    @Start
     public void start(Stage primaryStage) throws Exception {
         helpWindow = new HelpWindow();
-        helpWindow.show();
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -3,16 +3,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.testfx.framework.junit5.ApplicationTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
 
 import javafx.stage.Stage;
 
-
-public class HelpWindowTest extends ApplicationTest {
+@ExtendWith(ApplicationExtension.class)
+public class HelpWindowTest {
 
     private HelpWindow helpWindow;
 
-    @Override
+    @Start
     public void start(Stage primaryStage) {
         helpWindow = new HelpWindow(primaryStage);
     }
@@ -24,7 +26,7 @@ public class HelpWindowTest extends ApplicationTest {
 
     @Test
     public void checkOpenUrlInBrowser() {
-        assertDoesNotThrow(()-> {
+        assertDoesNotThrow(() -> {
             helpWindow.showHelp();
         });
     }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,31 +1,21 @@
 package seedu.address.ui;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.testfx.framework.junit5.ApplicationTest;
-import org.testfx.framework.junit5.Start;
 
-import javafx.stage.Stage;
+public class HelpWindowTest {
 
-
-public class HelpWindowTest extends ApplicationTest {
-
-    private HelpWindow helpWindow;
-    @Start
-    public void start(Stage primaryStage) throws Exception {
-        helpWindow = new HelpWindow();
-    }
+    public static final String USER_GUIDE = "https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html";
+    public static final String HELLP_MESSAGE = "https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html";
 
     @Test
     public void checkUserGuideUrl() {
-        assertEquals("https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html", HelpWindow.USERGUIDE_URL);
+        assertEquals(USER_GUIDE, HelpWindow.USERGUIDE_URL);
     }
 
     @Test
-    public void checkOpenUrlInBrowser() {
-        assertDoesNotThrow(() -> {
-            helpWindow.isShowing();
-        });
+    public void checkHelpMessage() {
+        assertEquals("Refer to the user guide: https://ay2425s1-cs2103t-w13-1.github.io/tp/UserGuide.html",
+                HelpWindow.HELP_MESSAGE);
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -3,20 +3,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.testfx.framework.junit5.ApplicationExtension;
-import org.testfx.framework.junit5.Start;
+import org.testfx.framework.junit5.ApplicationTest;
 
 import javafx.stage.Stage;
 
-@ExtendWith(ApplicationExtension.class)
-public class HelpWindowTest {
+
+public class HelpWindowTest extends ApplicationTest {
 
     private HelpWindow helpWindow;
-
-    @Start
-    public void start(Stage primaryStage) {
-        helpWindow = new HelpWindow(primaryStage);
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        helpWindow = new HelpWindow();
+        helpWindow.show();
     }
 
     @Test
@@ -27,7 +25,7 @@ public class HelpWindowTest {
     @Test
     public void checkOpenUrlInBrowser() {
         assertDoesNotThrow(() -> {
-            helpWindow.showHelp();
+            helpWindow.isShowing();
         });
     }
 }


### PR DESCRIPTION
Improve the help window's appearance.

1. The users now can read the user guide without leaving the app
2. The user can open the userguide on the browser with just one click


<img width="795" alt="image" src="https://github.com/user-attachments/assets/3230af0e-d134-45a3-84b6-1be73c52966b">

Fix #112 
