### PR TITLE
Improve the visibility of the status bar and the tags

### DIFF
--- a/src/main/resources/view/CherLightTheme.css
+++ b/src/main/resources/view/CherLightTheme.css
@@ -163,7 +163,7 @@
 
 .status-bar .label {
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: black;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
 }
@@ -175,7 +175,7 @@
 }
 
 .status-bar-with-border .label {
-    -fx-text-fill: white;
+    -fx-text-fill: black;
 }
 
 .grid-pane {
@@ -347,7 +347,7 @@
 }
 
 #tags .label {
-    -fx-text-fill: black;
+    -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;


### PR DESCRIPTION
Now the color of the tag is white to increase the readability 

<img width="117" alt="image" src="https://github.com/user-attachments/assets/aad05721-428d-42f2-9453-d45e00a2c0a4">


The text color of the status bar changed from white to black

<img width="243" alt="image" src="https://github.com/user-attachments/assets/fbc627eb-260e-4124-b2f3-545633238000">

Fix #151