### PR TITLE
Update help page

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -10,6 +10,8 @@ import java.util.logging.Logger;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
@@ -119,5 +121,14 @@ public class HelpWindow extends UiPart<Stage> {
         } catch (IOException | URISyntaxException e) {
             logger.warning("Failed to open URL: " + USERGUIDE_URL);
         }
+    }
+
+    @FXML
+    private void copyUrl() {
+        Clipboard clipboard = Clipboard.getSystemClipboard();
+        ClipboardContent content = new ClipboardContent();
+        content.putString(USERGUIDE_URL);
+        clipboard.setContent(content);
+        System.out.println("URL copied to clipboard: " + USERGUIDE_URL);
     }
 }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -30,7 +30,7 @@
                 <Insets right="5.0" />
               </HBox.margin>
             </Label>
-            <Button fx:id="urlButton" mnemonicParsing="false" onAction="#openUrlInBrowser" text="Open In Browser">
+            <Button fx:id="urlButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy the URL">
               <HBox.margin>
                 <Insets left="5.0" />
               </HBox.margin>


### PR DESCRIPTION
Update help page, as the module Desktop.open() is not supported in Linux without specifying default browser, as a result, it is easier to just allow the users to copy the URL